### PR TITLE
include citation to acknowledge gdverse dependency

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,13 @@
+citHeader("Note: cisp reorganizes selected functionality from gdverse.\nWhen using cisp in publications, please consider citing gdverse accordingly:")
+
+bibentry(
+  bibtype  = "Article",
+  title    = "gdverse: An R Package for Spatial Stratified Heterogeneity Family",
+  author   = "Wenbo Lv and Yangyang Lei and Fangmei Liu and Jianwu Yan and Yongze Song and Wufan Zhao",
+  journal  = "Transactions in GIS",
+  year     = "2025",
+  volume   = "29",
+  number   = "2",
+  pages    = "29:e70032",
+  doi      = "10.1111/tgis.70032"
+)

--- a/vignettes/cisp.rmd
+++ b/vignettes/cisp.rmd
@@ -65,7 +65,7 @@ system.time({
   g = cisp::spc(ndvi,cores = 6)
 })
 ##    user  system elapsed 
-##    0.66    0.26   24.88
+##    0.64    0.17   16.18
 g
 ## ***   Spatial Pattern Correlation    
 ## 


### PR DESCRIPTION
This PR uses the citation header in `inst/CITATION` to properly acknowledge the relationship between cisp and gdverse packages.

Changes:
- Modified `citHeader()` content to inform users that cisp reorganizes functionality originally developed in gdverse
- Encourages proper academic attribution by prompting users to cite gdverse when using cisp in publications

Rationale:
Since cisp builds upon and reorganizes selected functionality from gdverse, this update ensures appropriate credit is given to the upstream package in academic contexts, following R package citation best practices.