### PR TITLE
correct maintainer surname spelling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: cisp
 Title: A Correlation Indicator Based on Spatial Patterns 
 Version: 0.3.0
 Authors@R: c(
-      person(given = "Wenbo", family = "Lv",
+      person(given = "Wenbo", family = "Lyu",
              email = "lyu.geosocial@gmail.com", 
              role = c("aut", "cre", "cph"),
              comment = c(ORCID = "0009-0002-6003-3800")),

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -20,7 +20,7 @@ home:
   title: |
     cisp | A Correlation Indicator Based On Spatial Patterns
 authors:
-  Wenbo Lv:
+  Wenbo Lyu:
     href: https://spatlyu.github.io/
   Yongze Song:
     href: https://yongzesong.com/

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -8,6 +8,5 @@ bibentry(
   year     = "2025",
   volume   = "29",
   number   = "2",
-  pages    = "29:e70032",
   doi      = "10.1111/tgis.70032"
 )


### PR DESCRIPTION
This PR updates the maintainer name from `Wenbo Lv` to `Wenbo Lyu` to align with my official passport spelling.

## Background

- **Chinese name**: 吕文博
- **Previous English name**: Wenbo Lv
- **Passport spelling**: Wenbo Lyu

The spelling `Lyu` is the standardized ASCII representation of the surname "吕" (Lü) used in official Chinese documents, including passports. This change ensures consistency across all official and academic records.

## Changes

- Updated maintainer name in `DESCRIPTION` file
- Updated author information in package metadata
- Corrected citation file