### PR TITLE
fix bug of `ssh_marginalcontri` when `overlay` is assigned to `intersection`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Depends:
 Imports: 
     dplyr,
     forcats,
-    gdverse (>= 1.5),
+    gdverse (>= 1.6),
     ggplot2,
     ggraph,
     igraph,
@@ -49,5 +49,7 @@ Imports:
 Suggests: 
     knitr,
     rmarkdown,
-    spEDM
+    spEDM,
+    infoxtr,
+    pc
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cisp 0.3.0
 
+* Fix bug of `ssh_marginalcontri` when `overlay` is assigned to `intersection` （#27）
+
 # cisp 0.2.0
 
 * Optimize `spc` with OPGD for efficiency and rename the results table (#13).

--- a/R/ssh_marginalcontri.R
+++ b/R/ssh_marginalcontri.R
@@ -41,10 +41,10 @@ ssh_marginalcontri = \(formula, data, overlay = 'and', cores = 1){
   pd_mc = \(formula, discdata, overlaymethod = 'and'){
     formula = stats::as.formula(formula)
     formulavars = all.vars(formula)
-    if (formula.vars[2] != "."){
+    if (formulavars[2] != "."){
       discdata = dplyr::select(discdata,dplyr::all_of(formulavars))
     }
-    yname = formula.vars[1]
+    yname = formulavars[1]
     if (overlaymethod == 'intersection'){
       fuzzyzone = discdata |>
         dplyr::select(-dplyr::any_of(yname)) |>


### PR DESCRIPTION
In the previous version of `cisp`, the `spd` values were incorrectly calculated as 0 when using `overlay = "intersection"`:

``` r
res_spd_ntd = cisp::ssh_marginalcontri(
  "incidence ~ .", 
  data = dplyr::select(gdverse::NTDs, 1:4), 
  overlay = "intersection")
res_spd_ntd
#> ***   SSH Marginal Contributions    
#> 
#> | variable  | spd |
#> |:---------:|:---:|
#> | watershed |  0  |
#> | elevation |  0  |
#> | soiltype  |  0  |
```

This issue has now been fixed:

``` r
res_spd_ntd = cisp::ssh_marginalcontri(
  "incidence ~ .", 
  data = dplyr::select(gdverse::NTDs, 1:4), 
  overlay = "intersection")
res_spd_ntd
#> ***   SSH Marginal Contributions    
#> 
#> | variable  |    spd     |
#> |:---------:|:----------:|
#> | watershed | 0.12063395 |
#> | elevation | 0.07937803 |
#> | soiltype  | 0.05358794 |
```


